### PR TITLE
Ignore FrozenStringLiteralComment cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ Metrics/LineLength:
 
 Style/SpaceBeforeFirstArg:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
The version of rubocop that CircleCI installs complains about this
despite my local version (latest) does not! I think it's a silly
check, another case of Rubocop being anxious.
